### PR TITLE
HDF5 not needed in DynamicMemory.c example

### DIFF
--- a/Examples/DynamicMemory/Makefile
+++ b/Examples/DynamicMemory/Makefile
@@ -6,7 +6,7 @@ PKG_CONFIG=pkg-config
 all: DynamicMemory
 
 DynamicMemory: DynamicMemory.c
-	$(CC) DynamicMemory.c `$(PKG_CONFIG) --cflags --libs lgm` `$(PKG_CONFIG) --cflags --libs hdf5 &2> /dev/null` -Wall -o DynamicMemory
+	$(CC) DynamicMemory.c `$(PKG_CONFIG) --cflags --libs lgm` -Wall -o DynamicMemory
 
 clean:
 	rm DynamicMemory


### PR DESCRIPTION
We don't need the hdf5 libs in the DynamicMemory.c example