### PR TITLE
travis.yml: update to test on xenial and trusty, and add keys to work…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+    - os: linux
+      dist: xenial
+
 language: c
 
 compiler: gcc
 
 before_install:
+  - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 762E3157
   - sudo apt-get update -qq
   - sudo apt-get install -qq libperl-dev libgsl0-dev libhdf5-serial-dev
 


### PR DESCRIPTION
… around Travis issue

Travis CI (on the .org domain, not the .com domain), is having issues with apt-get.
This can be worked around following
https://travis-ci.community/t/then-sudo-apt-get-update-failed-public-key-is-not-available-no-pubkey-6b05f25d762e3157-in-ubuntu-xenial/1728
although it's unclear whether this is a temporary glitch or a permanent failure as the .org domain gets wound down.