### PR TITLE
Fix Lgm_Wrap runtime libdir refs when multiple lib dirs

### DIFF
--- a/Python/Makefile.am
+++ b/Python/Makefile.am
@@ -14,7 +14,7 @@ Lgm_Wrap_gen.py: $(top_builddir)/libLanlGeoMag/libLanlGeoMag.la $(LGMSRCDIR)/Lgm
 
 #only make final Lgm_Wrap on install, so it can rewrite the library directory
 Lgm_Wrap.py: FORCE Lgm_Wrap_gen.py
-	$(SED) -e 's|add_library_search_dirs(\['\''RUNTIME_LIBDIR'\''\])|add_library_search_dirs(\['\''$(libdir)'\''\])|' Lgm_Wrap_gen.py > Lgm_Wrap.py
+	$(SED) -e 's|^add_library_search_dirs(\[\(.*\)'\''RUNTIME_LIBDIR'\''\(.*\)\])$$|add_library_search_dirs(\[\1'\''$(libdir)'\''\2\])|' Lgm_Wrap_gen.py > Lgm_Wrap.py
 
 uninstall-hook:
 	-rmdir $(lgmpydir)


### PR DESCRIPTION
This fixed the problem Steve had when installing to a location that's not in some sort of runtime library path (not going to chase down which one!) The problem was that the Makefile rule to rewrite RUNTIME_LIBRARY_PATH to the lanlgeomag library path expected no other library paths, and hdf5 requires one.