### PR TITLE
Correct pitch angle setting in Lstar routine

### DIFF
--- a/libLanlGeoMag/ComputeLstar.c
+++ b/libLanlGeoMag/ComputeLstar.c
@@ -619,7 +619,7 @@ int Lstar( Lgm_Vector *vin, Lgm_LstarInfo *LstarInfo ){
      */
     u = *vin;
     LstarInfo->mInfo->Bfield( &u, &Bvec, LstarInfo->mInfo );
-    LstarInfo->mInfo-Blocal = Lgm_Magnitude( &Bvec );
+    LstarInfo->mInfo->Blocal = Lgm_Magnitude( &Bvec );
     if (LstarInfo->VerbosityLevel > 1) {
         printf("\n\t\t%sInitial Position, U_gsm (Re):            < %g, %g, %g >%s\n", PreStr, u.x, u.y, u.z, PostStr);
         printf("\t\t%sMag. Field Strength, B at U_gsm (nT):    %g%s\n", PreStr, LstarInfo->mInfo->Blocal, PostStr);

--- a/libLanlGeoMag/ComputeLstar.c
+++ b/libLanlGeoMag/ComputeLstar.c
@@ -618,11 +618,11 @@ int Lstar( Lgm_Vector *vin, Lgm_LstarInfo *LstarInfo ){
      *  Do Initial field Line to get Bm and I
      */
     u = *vin;
+    LstarInfo->mInfo->Bfield( &u, &Bvec, LstarInfo->mInfo );
+    LstarInfo->mInfo-Blocal = Lgm_Magnitude( &Bvec );
     if (LstarInfo->VerbosityLevel > 1) {
         printf("\n\t\t%sInitial Position, U_gsm (Re):            < %g, %g, %g >%s\n", PreStr, u.x, u.y, u.z, PostStr);
-	    LstarInfo->mInfo->Bfield( &u, &Bvec, LstarInfo->mInfo );
-	    B = Lgm_Magnitude( &Bvec );
-        printf("\t\t%sMag. Field Strength, B at U_gsm (nT):    %g%s\n", PreStr, B, PostStr);
+        printf("\t\t%sMag. Field Strength, B at U_gsm (nT):    %g%s\n", PreStr, LstarInfo->mInfo->Blocal, PostStr);
     }
     if ( Lgm_Trace( &u, &v1, &v2, &v3, LstarInfo->mInfo->Lgm_LossConeHeight, TRACE_TOL, TRACE_TOL, LstarInfo->mInfo ) == LGM_CLOSED ) {
 
@@ -631,7 +631,7 @@ int Lstar( Lgm_Vector *vin, Lgm_LstarInfo *LstarInfo ){
         LstarInfo->RofC    = LstarInfo->mInfo->d2B_ds2; // radius of curvature at Bmin point.
 
         sa = sin( LstarInfo->PitchAngle*RadPerDeg ); sa2 = sa*sa;
-        LstarInfo->mInfo->Bm = LstarInfo->mInfo->Bmin/sa2; // set Bmirror for supplied location, pitch angle, field model, etc.
+        LstarInfo->mInfo->Bm = LstarInfo->mInfo->Blocal/sa2; // set Bmirror for supplied location, pitch angle, field model, etc.
 
 	if (LstarInfo->VerbosityLevel > 1) {
             printf("\n\t\t%sMin-B  Point Location, Pmin (Re):      < %g, %g, %g >%s\n", PreStr, LstarInfo->mInfo->Pmin.x, LstarInfo->mInfo->Pmin.y, LstarInfo->mInfo->Pmin.z, PostStr);


### PR DESCRIPTION
Lstar requires Bmirror to find the drift shell (searching for (Bmirror, I) pairs). Bmirror was being calculated from the pitch angle and minimum B. Given that the user supplies a location and a pitch angle we want L* for a particle *of that pitch angle at that point*. So we need to populate the `Blocal` member of the mInfo structure and calculate Bmirror using Blocal and the local pitch angle.

This patch makes that change. Closes #19.