### PR TITLE
Add unit tests for LGM string functions, unify string funcs under Lgm_Misc

### DIFF
--- a/libLanlGeoMag/Lgm/Lgm_CTrans.h
+++ b/libLanlGeoMag/Lgm/Lgm_CTrans.h
@@ -855,8 +855,6 @@ void        Lgm_GEOD_to_WGS84( double GeodLat, double GeodLong, double GeodHiegh
 void        Lgm_Nutation( double T_TT, double nTerms, double *dPSi, double *dEps );
 int         IsoTimeStringToDateTime( char *TimeString, Lgm_DateTime *d, Lgm_CTrans *c );
 int         MonthStrToNum( char *str );
-char       *Lgm_StrToLower( char *str, int nmax );
-char       *Lgm_StrToUpper( char *str, int nmax );
 
 /*
  * Leap Second Related  Routines

--- a/libLanlGeoMag/Lgm/Lgm_Misc.h
+++ b/libLanlGeoMag/Lgm/Lgm_Misc.h
@@ -8,5 +8,7 @@
 
 void Lgm_ReplaceSubString2( char **OutStr, char *OrigStr, char *SubStr, char *RepStr );
 void Lgm_ReplaceSubString( char *OutStr, char *OrigStr, char *SubStr, char *RepStr );
+char *Lgm_StrToLower( char *str, int nmax );
+char *Lgm_StrToUpper( char *str, int nmax );
 
 #endif

--- a/libLanlGeoMag/Lgm_CTrans.c
+++ b/libLanlGeoMag/Lgm_CTrans.c
@@ -58,6 +58,7 @@
  */
 #include "Lgm/Lgm_CTrans.h"
 #include "Lgm/Lgm_Quat.h"
+#include "Lgm/Lgm_Misc.h"
 #include "config.h"
 
 #include <ctype.h>

--- a/libLanlGeoMag/Lgm_CTrans.c
+++ b/libLanlGeoMag/Lgm_CTrans.c
@@ -2331,7 +2331,7 @@ int MonthStrToNum( char *str ) {
 char *Lgm_StrToLower( char *str, int nmax ) {
     int  n = 0;
     char *p = str;
-    while ( (p != '\0' ) && (n<nmax) ){
+    while ( (*p != '\0' ) && (n<nmax) ){
 	    *p = (unsigned char)tolower(*p);
 	    ++p;
 	    ++n;
@@ -2342,7 +2342,7 @@ char *Lgm_StrToLower( char *str, int nmax ) {
 char *Lgm_StrToUpper( char *str, int nmax ) {
     int  n = 0;
     char *p = str;
-    while ( (p != '\0' ) && (n<nmax) ){
+    while ( (*p != '\0' ) && (n<nmax) ){
 	    *p = (unsigned char)toupper(*p);
 	    ++p;
 	    ++n;

--- a/libLanlGeoMag/Lgm_Misc.c
+++ b/libLanlGeoMag/Lgm_Misc.c
@@ -15,12 +15,9 @@ void Lgm_ReplaceSubString2( char **OutStr, char *OrigStr, char *SubStr, char *Re
     char    *p, *Str, *Str2, *p_remaining, *NewStr;
     int     q;
 
-
     // get sizes of strings 
     nSubStr = strlen( SubStr );
     nRepStr = strlen( RepStr );
-
-
 
     // Make a copy of the original string
     nStr = strlen( OrigStr );
@@ -28,14 +25,11 @@ void Lgm_ReplaceSubString2( char **OutStr, char *OrigStr, char *SubStr, char *Re
     strcpy( Str, OrigStr );
     printf("Str = %s n = %d\n", Str, nStr);
 
-
     // Allocate space for the NewStr -- initially we only need enough space for the null terminator
     q = 1;
     NewStr  = (char *)calloc( q, sizeof(char) );
     NewStr[q-1] = '\0'; // terminate it.
     nNewStr = strlen( NewStr );
-
-
 
     /*
      * Set pointer to look at the part of Str the we have left to
@@ -44,13 +38,11 @@ void Lgm_ReplaceSubString2( char **OutStr, char *OrigStr, char *SubStr, char *Re
     p_remaining = Str;
     done = 0;
     while ( !done ) {
-
         /*
          *  Using the string pointed to by p_remaining, attempt to locate an
          *  occurrence of SubStr
          */
         if ( !(p = strstr( p_remaining, SubStr )) ) {
-
             /*
              *   We didn't find an occurrence of SubStr in the String pointed to
              *   by p_remaining. So we are done.
@@ -66,9 +58,7 @@ void Lgm_ReplaceSubString2( char **OutStr, char *OrigStr, char *SubStr, char *Re
             nNewStr = strlen( NewStr );
 
             done = 1;
-
         } else {
-
             /*
              * We have found an occurrence of the substring. The pointer p
              * is pointing at it in the string p_remaining
@@ -107,16 +97,11 @@ void Lgm_ReplaceSubString2( char **OutStr, char *OrigStr, char *SubStr, char *Re
             p_remaining = p + nSubStr;
 
         }
-
     }
-
     free( Str );
 
-
     *OutStr = NewStr;
-
     return;
-
 }
 
 
@@ -136,12 +121,9 @@ void Lgm_ReplaceSubString( char *OutStr, char *OrigStr, char *SubStr, char *RepS
     char    *p, *Str, *Str2, *p_remaining, *NewStr;
     int     q;
 
-
     // get sizes of strings 
     nSubStr = strlen( SubStr );
     nRepStr = strlen( RepStr );
-
-
 
     // Make a copy of the original string
     nStr = strlen( OrigStr );
@@ -149,14 +131,11 @@ void Lgm_ReplaceSubString( char *OutStr, char *OrigStr, char *SubStr, char *RepS
     strcpy( Str, OrigStr );
     printf("Str = %s n = %d\n", Str, nStr);
 
-
     // Allocate space for the NewStr -- initially we only need enough space for the null terminator
     q = 1;
     NewStr  = (char *)calloc( q, sizeof(char) );
     NewStr[q-1] = '\0'; // terminate it.
     nNewStr = strlen( NewStr );
-
-
 
     /*
      * Set pointer to look at the part of Str the we have left to
@@ -165,13 +144,11 @@ void Lgm_ReplaceSubString( char *OutStr, char *OrigStr, char *SubStr, char *RepS
     p_remaining = Str;
     done = 0;
     while ( !done ) {
-
         /*
          *  Using the string pointed to by p_remaining, attempt to locate an
          *  occurrence of SubStr
          */
         if ( !(p = strstr( p_remaining, SubStr )) ) {
-
             /*
              *   We didn't find an occurrence of SubStr in the String pointed to
              *   by p_remaining. So we are done.
@@ -187,9 +164,7 @@ void Lgm_ReplaceSubString( char *OutStr, char *OrigStr, char *SubStr, char *RepS
             nNewStr = strlen( NewStr );
 
             done = 1;
-
         } else {
-
             /*
              * We have found an occurrence of the substring. The pointer p
              * is pointing at it in the string p_remaining
@@ -226,20 +201,12 @@ void Lgm_ReplaceSubString( char *OutStr, char *OrigStr, char *SubStr, char *RepS
             nNewStr = strlen(NewStr);
 
             p_remaining = p + nSubStr;
-
         }
-
     }
-
     free( Str );
-
 
     strcpy( OutStr, NewStr );
     free( NewStr);
-
     return;
 
 }
-
-
-

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,8 +1,8 @@
 ## Process this file with automake to produce Makefile.in
 
 lgm_includes=$(top_srcdir)/libLanlGeoMag/Lgm/
-check_PROGRAMS = check_libLanlGeoMag check_ClosedField check_McIlwain_L check_PolyRoots check_Magmodels check_Sgp4 check_DE421 check_CoordTrans check_IsoTimeStringToDateTime check_Lstar
-TESTS          = check_libLanlGeoMag check_ClosedField check_McIlwain_L check_PolyRoots check_Magmodels check_Sgp4 check_DE421 check_CoordTrans check_IsoTimeStringToDateTime check_Lstar
+check_PROGRAMS = check_libLanlGeoMag check_ClosedField check_McIlwain_L check_PolyRoots check_Magmodels check_Sgp4 check_DE421 check_CoordTrans check_IsoTimeStringToDateTime check_Lstar check_string_funcs
+TESTS          = check_libLanlGeoMag check_ClosedField check_McIlwain_L check_PolyRoots check_Magmodels check_Sgp4 check_DE421 check_CoordTrans check_IsoTimeStringToDateTime check_Lstar check_string_funcs
 
 check_libLanlGeoMag_SOURCES = check_libLanlGeoMag.c $(lgm_includes)/Lgm_CTrans.h
 check_libLanlGeoMag_CFLAGS = @CHECK_CFLAGS@
@@ -43,5 +43,9 @@ check_DE421_LDADD = $(top_builddir)/libLanlGeoMag/.libs/libLanlGeoMag.a @CHECK_L
 check_CoordTrans_SOURCES = check_CoordTrans.c $(lgm_includes)/Lgm_CTrans.h $(lgm_includes)/Lgm_Vec.h
 check_CoordTrans_CFLAGS = @CHECK_CFLAGS@
 check_CoordTrans_LDADD = $(top_builddir)/libLanlGeoMag/.libs/libLanlGeoMag.a @PERL_LDFLAGS@ @CHECK_LIBS@
+
+check_string_funcs_SOURCES = check_string_funcs.c $(lgm_includes)/Lgm_CTrans.h $(lgm_includes)/Lgm_Misc.h
+check_string_funcs_CFLAGS = @CHECK_CFLAGS@
+check_string_funcs_LDADD = $(top_builddir)/libLanlGeoMag/.libs/libLanlGeoMag.a @PERL_LDFLAGS@ @CHECK_LIBS@
 
 EXTRA_DIST = check_Lstar.expected check_McIlwain_L_01.expected check_McIlwain_L_02.expected check_McIlwain_L_03.expected check_McIlwain_L_04.expected check_McIlwain_L_05.expected check_McIlwain_L_06.expected check_McIlwain_L_07.expected check_McIlwain_L_08.expected check_PolyRoots_01.expected check_PolyRoots_02.expected check_PolyRoots_03.expected check_PolyRoots_04.expected check_Sgp4_01.expected testpo.421 check_CoordTrans.expected check_CoordTransNoEph.expected check_CoordDipoleTilt.expected check_Magmodels_01.expected check_ClosedField_01.expected

--- a/tests/check_string_funcs.c
+++ b/tests/check_string_funcs.c
@@ -1,0 +1,103 @@
+// REALLY NEED TO CHECK ALL THE PARAMS
+#include <check.h>
+#include "../libLanlGeoMag/Lgm/Lgm_Misc.h"
+
+/*BEGIN String case test case*/
+
+START_TEST(test_StrToLower) {
+
+    char*        Result;
+    char         TestString[128];
+
+    printf("Starting test_StrToUpper\n");
+    sprintf(TestString, "AN_UPPER_CASE_STRING");
+    printf("Converting string to  lower: %s\n", TestString);
+    Result = Lgm_StrToLower(TestString, 128);
+    printf("Result: %s\n\n", TestString);
+    fflush(stdout);
+    fail_unless(!strcmp(TestString, "an_upper_case_string"));
+    return;
+}
+END_TEST
+
+START_TEST(test_StrToUpper) {
+
+    char*        Result;
+    char         TestString[128];
+
+    printf("Starting test_StrToUpper\n");
+    sprintf(TestString, "a_lower_case_string");
+    printf("Converting string to upper: %s\n", TestString);
+    Result = Lgm_StrToUpper(TestString, 128);
+    printf("Result: %s\n\n", TestString);
+    fflush(stdout);
+    fail_unless(!strcmp(TestString, "A_LOWER_CASE_STRING"));
+    return;
+}
+END_TEST
+
+START_TEST(test_ReplaceSubString) {
+
+    int          Result;
+    char         TestString[128], NewString[128], Substr[5];
+
+    printf("Starting test_ReplaceSubString\n");
+    sprintf(Substr, "%02d", 4);
+    sprintf(TestString, "2024-%MM-01T12:00:00Z");
+    printf("Replacing wildcard substring: %s\n", TestString);
+    Lgm_ReplaceSubString(NewString, TestString, "%MM", Substr);
+    printf("Result: %s\n\n", NewString);
+    fflush(stdout);
+    fail_unless(!strcmp(NewString, "2024-04-01T12:00:00Z"));
+    return;
+}
+END_TEST
+
+START_TEST(test_ReplaceSubString2) {
+
+    char         TestString[128], Substr[5];
+    char*        NewString;
+
+    printf("Starting test_ReplaceSubString2\n");
+    sprintf(Substr, "%02d", 4);
+    sprintf(TestString, "2024-%MM-01T12:00:00Z");
+    printf("Replacing wildcard substring: %s\n", TestString);
+    Lgm_ReplaceSubString2(&NewString, TestString, "%MM", Substr);
+    printf("Result: %s\n\n", NewString);
+    fflush(stdout);
+    fail_unless(!strcmp(NewString, "2024-04-01T12:00:00Z"));
+    free(NewString);
+    return;
+}
+END_TEST
+
+
+Suite *ManipStr_suite(void) {
+
+  Suite *s = suite_create("STRING_FUNCTION_TESTS");
+
+  TCase *tc_manipStr = tcase_create("ISO Time Parser");
+  tcase_add_test(tc_manipStr, test_StrToLower);
+  tcase_add_test(tc_manipStr, test_StrToUpper);
+  tcase_add_test(tc_manipStr, test_ReplaceSubString);
+  tcase_add_test(tc_manipStr, test_ReplaceSubString2);
+  suite_add_tcase(s, tc_manipStr);
+
+  return s;
+
+}
+
+int main(void) {
+
+    int      number_failed;
+    Suite   *s  = ManipStr_suite();
+    SRunner *sr = srunner_create(s);
+
+    printf("\n\n");
+    srunner_run_all(sr, CK_ENV);
+    number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+
+}


### PR DESCRIPTION
This PR adds unit tests for the four main string handling functions: `Lgm_StrToLower`, `Lgm_StrToUpper`, `Lgm_ReplaceSubString`, and `Lgm_ReplaceSubString2`.

The case conversion functions have also been moved to join the substring replacement functions in `Lgm_Misc` to group like with like.

Finally, the null comparison in the case conversion now dereferences the char pointer (cleans up some compiler complaints).