### PR TITLE
Fix incomplete declarations to squelch warnings

### DIFF
--- a/libLanlGeoMag/Lgm/Lgm_MagModelInfo.h
+++ b/libLanlGeoMag/Lgm/Lgm_MagModelInfo.h
@@ -142,11 +142,13 @@ typedef struct CircularBuffer {
 
 } CircularBuffer;
 
-typedef struct Lgm_MagModelInfo {
+typedef struct Lgm_MagModelInfo Lgm_MagModelInfo;
+
+struct Lgm_MagModelInfo {
 
     Lgm_CTrans  *c;                 /* This contains all time info and a bunch more stuff */
     long int	nFunc;
-    int 		(*Bfield)();
+    int 		(*Bfield)(Lgm_Vector*, Lgm_Vector*, Lgm_MagModelInfo*);
     int			SavePoints;
     double		Hmax;
     FILE	    *fp;
@@ -566,7 +568,7 @@ typedef struct Lgm_MagModelInfo {
     void        *Data;
 
 
-} Lgm_MagModelInfo;
+} ;
 void Lgm_GSM_TO_PQB( Lgm_Vector *u_gsm, Lgm_Vector *u_pqb, Lgm_MagModelInfo *m );
 void Lgm_Set_GSM_TO_PQB( Lgm_Vector *Position, Lgm_MagModelInfo *m );
 void Lgm_PQB_TO_GSM( Lgm_Vector *u_pqb, Lgm_Vector *u_gsm, Lgm_MagModelInfo *m );

--- a/libLanlGeoMag/Lgm_B_FromScatteredData.c
+++ b/libLanlGeoMag/Lgm_B_FromScatteredData.c
@@ -500,7 +500,7 @@ int Lgm_B_FromScatteredData3( Lgm_Vector *v, Lgm_Vector *B, Lgm_MagModelInfo *In
     unsigned long int  *I_data;
     unsigned long int  *LookUpKey;                // key comprised of an array of unsigned long int Id's
     int                 KeyLength;                // length (in bytes) of LookUpKey
-    int                 (*Dipole)();         // tmp Pointer to Bfield function
+    int                 (*Dipole)(Lgm_Vector*, Lgm_Vector*, Lgm_MagModelInfo*);         // tmp Pointer to Bfield function
 
 
     /*
@@ -899,7 +899,7 @@ int Lgm_B_FromScatteredData4( Lgm_Vector *v, Lgm_Vector *B, Lgm_MagModelInfo *In
     unsigned long int  *I_data;
     unsigned long int  *LookUpKey;                // key comprised of an array of unsigned long int Id's
     int                 KeyLength;                // length (in bytes) of LookUpKey
-    int                 (*Dipole)();         // tmp Pointer to Bfield function
+    int                 (*Dipole)(Lgm_Vector*, Lgm_Vector*, Lgm_MagModelInfo*);         // tmp Pointer to Bfield function
 
 
     /*
@@ -1305,7 +1305,7 @@ int Lgm_B_FromScatteredData5( Lgm_Vector *v, Lgm_Vector *B, Lgm_MagModelInfo *In
     unsigned long int  *I_data;
     unsigned long int  *LookUpKey;                // key comprised of an array of unsigned long int Id's
     int                 KeyLength;                // length (in bytes) of LookUpKey
-    int                 (*Dipole)();              // tmp Pointer to Bfield function
+    int                 (*Dipole)(Lgm_Vector*, Lgm_Vector*, Lgm_MagModelInfo*);              // tmp Pointer to Bfield function
 
 
 //if (Info->KdTree_kNN_MaxDist2 < 1e8) printf("AHA Info->KdTree_kNN_MaxDist2 = %g\n", Info->KdTree_kNN_MaxDist2 );
@@ -2229,7 +2229,7 @@ int Lgm_B_FromScatteredData6( Lgm_Vector *v, Lgm_Vector *B, Lgm_MagModelInfo *In
     unsigned long int  *I_data;
     unsigned long int  *LookUpKey;                // key comprised of an array of unsigned long int Id's
     int                 KeyLength;                // length (in bytes) of LookUpKey
-    int                 (*Dipole)();         // tmp Pointer to Bfield function
+    int                 (*Dipole)(Lgm_Vector*, Lgm_Vector*, Lgm_MagModelInfo*);         // tmp Pointer to Bfield function
 
 
     /*


### PR DESCRIPTION
There are quite a few warnings of the form
`
passing arguments to a function without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
`
that we can silence now and prevent from graduating into errors with future C.

These seem to be caused by 
- incompletely specifying the Lgm_MagModelInfo's Bfield member, a pointer to a function that we can prototype fully if we first declare the struct (since *Bfield takes two vecs and a magmodelinfo as arguments), and 
- some similar things in libLanlGeoMag/Lgm_B_FromScatteredData.c where we just do the same to remove fussing there

This tests with our CrayPE, my local clang, and my local gcc (although the last one fusses with newer GNU and C standards).