### PR TITLE
Update CI image to Ubuntu 24.04

### DIFF
--- a/.github/workflows/lgm-ci.yml
+++ b/.github/workflows/lgm-ci.yml
@@ -12,13 +12,13 @@ on:
 
 jobs:
   basic-suite:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Install dependencies
       run: |
         sudo apt-get update -qq
         sudo apt-get install -y make gcc g++ autotools-dev autoconf check
-        sudo apt-get install -y libgsl-dev libgsl23 gsl-bin libgsl-dbg
+        sudo apt-get install -y libgsl-dev libgslcblas0 gsl-bin libgsl-dbg
         sudo apt-get install -y libhdf5-dev libperl-dev
         gcc --version
         gsl-config --version


### PR DESCRIPTION
The Ubuntu 20.04 image used for the CI has aged out and the tests no longer run.
This PR changes the base image used for CI to Ubuntu 24.04.